### PR TITLE
Include Cloudinary gem usage for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,12 +34,12 @@ gem 'font-awesome-sass'
 gem 'simple_form'
 
 gem 'devise'
+gem 'cloudinary', '~> 1.16.0'
 
 group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'dotenv-rails'
-  gem 'cloudinary', '~> 1.16.0'
 
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
Before cloudinary gem was on development and test only, so the production server was giving a 500 error